### PR TITLE
【Fixed】対象一覧の画像だけまたは名前だけ表示する機能

### DIFF
--- a/app/controllers/meeting_logs_controller.rb
+++ b/app/controllers/meeting_logs_controller.rb
@@ -52,6 +52,20 @@ class MeetingLogsController < ApplicationController
     flash[:notice] = "対象の記録を削除しました"
   end
 
+  def name_only
+    @tags = Tag.all
+    if params[:meeting_log].nil?
+      @meeting_logs = MeetingLog.page(params[:page])
+    elsif params[:meeting_log][:search] && params[:meeting_log][:tag_id].blank?
+      @meeting_logs = MeetingLog.search(params[:meeting_log][:name]).page(params[:page])
+    elsif params[:meeting_log][:name].blank? && params[:meeting_log][:tag_id]
+      @meeting_logs = MeetingLog.joins(:tags).search(params[:meeting_log][:tag_id]).page(params[:page])
+    else
+      redirect_to meeting_logs_path
+    end
+    @meeting_logs = MeetingLog.all.order(:status).page(params[:page]) if params[:sort_status]
+  end
+
   private
 
   def meeting_log_params

--- a/app/controllers/meeting_logs_controller.rb
+++ b/app/controllers/meeting_logs_controller.rb
@@ -66,6 +66,20 @@ class MeetingLogsController < ApplicationController
     @meeting_logs = MeetingLog.all.order(:status).page(params[:page]) if params[:sort_status]
   end
 
+  def image_only
+    @tags = Tag.all
+    if params[:meeting_log].nil?
+      @meeting_logs = MeetingLog.page(params[:page])
+    elsif params[:meeting_log][:search] && params[:meeting_log][:tag_id].blank?
+      @meeting_logs = MeetingLog.search(params[:meeting_log][:name]).page(params[:page])
+    elsif params[:meeting_log][:name].blank? && params[:meeting_log][:tag_id]
+      @meeting_logs = MeetingLog.joins(:tags).search(params[:meeting_log][:tag_id]).page(params[:page])
+    else
+      redirect_to meeting_logs_path
+    end
+    @meeting_logs = MeetingLog.all.order(:status).page(params[:page]) if params[:sort_status]
+  end
+
   private
 
   def meeting_log_params

--- a/app/views/meeting_logs/_menu.html.erb
+++ b/app/views/meeting_logs/_menu.html.erb
@@ -14,5 +14,5 @@
 
 <div class="learning">
   <%= link_to "名前だけ表示する", name_only_meeting_logs_path %>
-  <%= link_to "画像だけ表示する", name_only_meeting_logs_path %>
+  <%= link_to "画像だけ表示する", image_only_meeting_logs_path %>
 </div>

--- a/app/views/meeting_logs/_menu.html.erb
+++ b/app/views/meeting_logs/_menu.html.erb
@@ -1,0 +1,18 @@
+<h3>対象の一覧画面！</h3>
+
+<div class="sort">
+  <%= link_to "記憶状況でソートする", meeting_logs_path(sort_status: "true") %>
+</div>
+<div class="search">
+  <%= form_with(model: MeetingLog.new, url: meeting_logs_path, local: true, method: 'get') do |f| %>
+    <%= f.text_field :name, placeholder: "対象の名前から検索" %>　
+    <%= f.select :tag_id, @tags.pluck(:name), prompt: "タグから検索" %>
+    <%= f.hidden_field :search, value: 'true' %>　
+    <%= f.submit "検索" %>
+  <% end %>
+</div>
+
+<div class="learning">
+  <%= link_to "名前だけ表示する", name_only_meeting_logs_path %>
+  <%= link_to "画像だけ表示する", name_only_meeting_logs_path %>
+</div>

--- a/app/views/meeting_logs/image_only.html.erb
+++ b/app/views/meeting_logs/image_only.html.erb
@@ -8,10 +8,12 @@
       <td><%= image_tag m.image.url %></td>
     </tr>
     <tr>
-      <td>▼名前を表示する</td>
-    </tr>
-    <tr>
-      <td><%= link_to (m.name), meeting_log_path(m.id) %> さん</td>
+      <td>
+        <details>
+          <summary>名前を表示する</summary>
+          <%= link_to (m.name), meeting_log_path(m.id) %> さん
+        </details>
+      </td>
     </tr>
     <tr>
       <td><%= m.position %></td>
@@ -20,3 +22,16 @@
 </table>
 
 <%= paginate @meeting_logs %>
+
+
+
+<a data-toggle="collapse" href="#demo">click me</a>
+<div id="demo" class="collapse">
+  Bootstrapは、モバイルファーストウェブサイトを開発するための最も一般的なHTML、CSS、およびJavaScriptフレームワークです。<br/>
+</div>
+
+
+<details>
+<summary>『sample.mp4』をダウンロードしています。</summary>
+hoge
+</details>

--- a/app/views/meeting_logs/image_only.html.erb
+++ b/app/views/meeting_logs/image_only.html.erb
@@ -22,16 +22,3 @@
 </table>
 
 <%= paginate @meeting_logs %>
-
-
-
-<a data-toggle="collapse" href="#demo">click me</a>
-<div id="demo" class="collapse">
-  Bootstrapは、モバイルファーストウェブサイトを開発するための最も一般的なHTML、CSS、およびJavaScriptフレームワークです。<br/>
-</div>
-
-
-<details>
-<summary>『sample.mp4』をダウンロードしています。</summary>
-hoge
-</details>

--- a/app/views/meeting_logs/image_only.html.erb
+++ b/app/views/meeting_logs/image_only.html.erb
@@ -1,0 +1,22 @@
+<%= render partial: "menu" %>
+
+<br>
+
+<table>
+  <% @meeting_logs.each do |m| %>
+    <tr>
+      <td><%= image_tag m.image.url %></td>
+    </tr>
+    <tr>
+      <td>▼名前を表示する</td>
+    </tr>
+    <tr>
+      <td><%= link_to (m.name), meeting_log_path(m.id) %> さん</td>
+    </tr>
+    <tr>
+      <td><%= m.position %></td>
+    </tr>
+  <% end %>
+</table>
+
+<%= paginate @meeting_logs %>

--- a/app/views/meeting_logs/index.html.erb
+++ b/app/views/meeting_logs/index.html.erb
@@ -1,21 +1,4 @@
-<h3>対象の一覧画面</h3>
-
-<div class="sort">
-  <%= link_to "記憶状況でソートする", meeting_logs_path(sort_status: "true") %>
-</div>
-<div class="search">
-  <%= form_with(model: MeetingLog.new, url: meeting_logs_path, local: true, method: 'get') do |f| %>
-    <%= f.text_field :name, placeholder: "対象の名前から検索" %>　
-    <%= f.select :tag_id, @tags.pluck(:name), prompt: "タグから検索" %>
-    <%= f.hidden_field :search, value: 'true' %>　
-    <%= f.submit "検索" %>
-  <% end %>
-</div>
-
-<div class="learning">
-  <%= link_to "名前だけ表示する", name_only_meeting_logs_path %>
-  <%= link_to "画像だけ表示する", name_only_meeting_logs_path %>
-</div>
+<%= render partial: "menu" %>
 
 <br>
 

--- a/app/views/meeting_logs/name_only.html.erb
+++ b/app/views/meeting_logs/name_only.html.erb
@@ -12,37 +12,19 @@
   <% end %>
 </div>
 
-<div class="learning">
-  <%= link_to "名前だけ表示する", name_only_meeting_logs_path %>
-  <%= link_to "画像だけ表示する", name_only_meeting_logs_path %>
-</div>
-
 <br>
 
 <table>
   <% @meeting_logs.each do |m| %>
     <tr>
+      <td><%= link_to (m.name), meeting_log_path(m.id) %> さん</td>
+    </tr>
+    <tr><<td>▼画像を表示する</td></tr>
+    <tr>
       <td><%= image_tag m.image.url %></td>
     </tr>
     <tr>
-      <td><%= link_to (m.name), meeting_log_path(m.id) %> さん</td>
-    </tr>
-    <tr>
       <td><%= m.position %></td>
-    </tr>
-    <tr>
-      <td>
-        <% m.tags.each do |tag| %>
-          #<%= tag.name %>
-          <% end %>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <%= m.status %>,
-        <%= link_to "編集", edit_meeting_log_path(m.id) %>
-        <%= link_to "削除", meeting_log_path(m.id), method: :delete, data: {confirm: "対象の記録を削除しますか？"} %>
-      </td>
     </tr>
   <% end %>
 </table>

--- a/app/views/meeting_logs/name_only.html.erb
+++ b/app/views/meeting_logs/name_only.html.erb
@@ -1,16 +1,4 @@
-<h3>対象の一覧画面</h3>
-
-<div class="sort">
-  <%= link_to "記憶状況でソートする", meeting_logs_path(sort_status: "true") %>
-</div>
-<div class="search">
-  <%= form_with(model: MeetingLog.new, url: meeting_logs_path, local: true, method: 'get') do |f| %>
-    <%= f.text_field :name, placeholder: "対象の名前から検索" %>　
-    <%= f.select :tag_id, @tags.pluck(:name), prompt: "タグから検索" %>
-    <%= f.hidden_field :search, value: 'true' %>　
-    <%= f.submit "検索" %>
-  <% end %>
-</div>
+<%= render partial: "menu" %>
 
 <br>
 

--- a/app/views/meeting_logs/name_only.html.erb
+++ b/app/views/meeting_logs/name_only.html.erb
@@ -7,9 +7,13 @@
     <tr>
       <td><%= link_to (m.name), meeting_log_path(m.id) %> さん</td>
     </tr>
-    <tr><<td>▼画像を表示する</td></tr>
     <tr>
-      <td><%= image_tag m.image.url %></td>
+      <td>
+        <details>
+          <summary>画像を表示する</summary>
+          <%= image_tag m.image.url %>
+        </details>
+      </td>
     </tr>
     <tr>
       <td><%= m.position %></td>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
     resources :comments
     collection do
       get 'name_only'
+      get 'image_only'
     end
   end
   resources :tags, only:[:index, :create, :destroy]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,9 @@ Rails.application.routes.draw do
   devise_for :users
   resources :meeting_logs do
     resources :comments
+    collection do
+      get 'name_only'
+    end
   end
   resources :tags, only:[:index, :create, :destroy]
   resources :users, only: [:show]


### PR DESCRIPTION
#9 

**対象一覧のうち名前だけ・画像だけを表示する画面を作成**
- ルーティングに「name_only」「image_only」を追加。
- meeting_logsコントローラに「name_only」「image_only」アクションを追加。
- meeting_logsビューに「name_only」「image_only」を追加。
- meeting_logs/_menu.html.erbを作成（パーシャル）
  - meeting_logs/index.html.erbから、name_only.html.erbとimage_only.html.erbとの共通部分を切り出して作成。
- detailsタグで画像（または名前）の表示・非表示の切り替えを実装。