### PR TITLE
【Fixed】statusを切り替える機能 #26

### DIFF
--- a/app/controllers/meeting_logs_controller.rb
+++ b/app/controllers/meeting_logs_controller.rb
@@ -1,6 +1,6 @@
 class MeetingLogsController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_meeting_log, only: [:edit, :update, :show, :destroy]
+  before_action :set_meeting_log, only: [:edit, :update, :show, :destroy, :toggle_status]
   before_action :ensure_correct_user, only: [:edit, :update, :show, :destroy]
 
   def index
@@ -82,6 +82,11 @@ class MeetingLogsController < ApplicationController
     @meeting_logs = current_user.meeting_logs.all.order(:status).page(params[:page]) if params[:sort_status]
   end
 
+  def toggle_status
+    @meeting_log.toggle_status!
+    redirect_to @meeting_log, notice: '記憶状況を更新しました'
+  end
+
   private
 
   def meeting_log_params
@@ -90,7 +95,7 @@ class MeetingLogsController < ApplicationController
   end
 
   def set_meeting_log
-    @meeting_log = MeetingLog.find(params[:id])
+    @meeting_log = MeetingLog.find(params[:id] || params[:meeting_log_id])
   end
 
   def ensure_correct_user

--- a/app/models/meeting_log.rb
+++ b/app/models/meeting_log.rb
@@ -25,6 +25,14 @@ class MeetingLog < ApplicationRecord
     attributes tag: ["tags.name"]
   end
 
+  def toggle_status!
+    if memorizing?
+      memorized!
+    else
+      memorizing!
+    end
+  end
+
   private
 
   def day_cannot_future

--- a/app/views/meeting_logs/show.html.erb
+++ b/app/views/meeting_logs/show.html.erb
@@ -8,7 +8,7 @@
       <td>
         <table class="mypage-intable1">
           <tr><td><%= image_tag @meeting_log.image.url %></td></tr>
-          <tr><td>状態： <%= @meeting_log.status_i18n %> です！</td></tr>
+          <tr><td>状況： <%= link_to @meeting_log.status_i18n, meeting_log_toggle_status_path(@meeting_log), method: :patch %> です！</td></tr>
         </table>
       </td>
       <td>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   root to: 'users#index'
   devise_for :users
   resources :meeting_logs do
+    patch :toggle_status
     resources :comments
     collection do
       get 'name_only'


### PR DESCRIPTION
closes #26 

**対象詳細画面にstatus（記憶状況）を切り替えるリンクを作成**
- meetinglogモデルにtoggle_status!メソッドを作成。
- meeting_logsコントローラにtoggle_statusアクションを作成。