### PR TITLE
【Fixed】対象の名前（画像）のみの一覧画面から、「名前（画像）だけ表示」のリンクをクリックするとエラー #29

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,7 +18,7 @@
             <% if user_signed_in? %>
               <li><%= link_to t('action.list'), meeting_logs_path %></li>
               <li><%= link_to t('action.record'), new_meeting_log_path %></li>
-              <li><%= link_to "マイページ", user_path(current_user.id) %></li>
+              <li><%= link_to t('user.show'), user_path(current_user.id) %></li>
               <li><%= link_to t('action.tag'), tags_path %></li>
               <li><%= link_to t('action.logout'), destroy_user_session_path, method: :delete %></li>
             <% else %>

--- a/app/views/meeting_logs/_menu.html.erb
+++ b/app/views/meeting_logs/_menu.html.erb
@@ -1,13 +1,13 @@
 <!-- 対象一覧画面上部 -->
 <div class="meetinglog-index-menu">
   <div class="circle-meetinglog">
-    <%= link_to 'meeting_logs/name_only' do %>
+    <%= link_to name_only_meeting_logs_path do %>
       <p class="new-line">名前だけ<br>表示する</p>
     <% end %>
   </div>
 
   <div class="circle-meetinglog">
-    <%= link_to 'meeting_logs/image_only' do %>
+    <%= link_to  image_only_meeting_logs_path do %>
       <p class="new-line">画像だけ<br>表示する</p>
     <% end %>
   </div>


### PR DESCRIPTION
closes #29 