### PR TITLE
タグ管理画面からページネーションを削除

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -2,7 +2,7 @@ class TagsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @tags = Tag.all.page(params[:page])
+    @tags = Tag.all.page
     @tag = Tag.new
   end
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,5 +1,4 @@
 class Tag < ApplicationRecord
   validates :name, presence: true, length: { maximum: 15 }, uniqueness: true
   has_many :taggings, dependent: :destroy
-  paginates_per 10
 end

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -10,6 +10,5 @@
     <% end %>
   </table>
   <br>
-  <%= paginate @tags %>
   <%= render "new" %>
 </div>


### PR DESCRIPTION
**タグ管理画面に表示していたページネーションを削除**
- 管理上、一望出来た方が良いと思われるため。