### PR TITLE
【Fixed】[ユーザー画面]users/edit(delete) アカウント削除ができない

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   validates :name, presence: true, length: { maximum: 30 }, uniqueness: true
-  has_many :meeting_logs
-  has_many :tags
+  has_many :meeting_logs, dependent: :destroy
+  has_many :tags, dependent: :destroy
   mount_uploader :image, ImageUploader
 end


### PR DESCRIPTION
closes #64 
- Userを削除するとき、関連づけられたオブジェクト（TagとMeetingLog）も同時に削除されるよう修正。