### PR TITLE
【Fixed】[タグ管理画面]/tags 重複するタグを作成するとエラーページに移行する

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -8,6 +8,7 @@ class TagsController < ApplicationController
 
   def create
     @tag = current_user.tags.build(tag_params)
+    @tags = current_user.tags.page
     if @tag.save
       redirect_to tags_path
       flash[:notice] = "新しいタグを作成しました"


### PR DESCRIPTION
closes #65 
- タグ作成時、バリデーション（タグ名の重複、文字数、存在性）に失敗するとエラー画面に移行する。 --> バリデーション失敗時はエラーメッセージを表示させるよう修正。